### PR TITLE
Remove extraneous closing brace in test

### DIFF
--- a/test/mockserver.jl
+++ b/test/mockserver.jl
@@ -17,7 +17,7 @@ function handle(color)
     current_color = color
     HttpHandler() do req::Request, res::Response
         if ismatch(r"^/initial", req.resource)
-            Response("""{"typ": "any", "value": ""}}""")
+            Response("""{"typ": "any", "value": ""}""")
         elseif ismatch(r"^/query", req.resource)
             param = JSON.parse(bytes_to_string(req.data))
             if "Setter" == param["type"]


### PR DESCRIPTION
Seems like this was a typo that causes tests to fail with JSON v0.6.0.
